### PR TITLE
doc(docs): AoC - add locked next day button to bottom of page

### DIFF
--- a/advent-of-calm/website/src/pages/day/[day].astro
+++ b/advent-of-calm/website/src/pages/day/[day].astro
@@ -85,6 +85,15 @@ const nextUnlocked = nextDay && isUnlocked(nextDay);
           </svg>
         </a>
       )}
+      {nextDay && !nextUnlocked && (
+        <span class="nav-button next locked" title={`Unlocks December ${nextDay}`}>
+          Day {nextDay}
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
+            <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+          </svg>
+        </span>
+      )}
     </div>
   </nav>
 </Layout>


### PR DESCRIPTION
Currently the top of the page has prev/calendar/next button (where next is either unlocked or locked).
The bottom has prev/calendar, and next only if unlocked.

This PR adds the next button when its in the locked state, to be consistent with the header.

<img width="1124" height="246" alt="{903B51C1-4A5F-4DFE-868C-490527F26E51}" src="https://github.com/user-attachments/assets/30082a7b-ff2b-4f17-adc5-9f55271b1cb3" />

