### PR TITLE
fix: remove committed node_modules symlink and harden gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,9 @@ docs/contributing.md
 **/.vscode**/
 /.vscode/settings.json
 
-node_modules/
+# No trailing slash: also ignores a `node_modules` symlink (git stores symlinks
+# as files, so a trailing-slash pattern would not match them) — see issue #2707
+node_modules
 **/dist/
 **/.vscode-test/
 **/out/

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/matthewbain/Development/github/architecture-as-code/node_modules


### PR DESCRIPTION
## Description
A `node_modules` symlink was accidentally committed to the repository root in PR #2700 (commit `7d9f915`). It pointed at an absolute path on the author's machine (`/Users/matthewbain/Development/github/architecture-as-code/node_modules`), so it was meaningless to everyone else and dirtied fresh clones.

This PR:
- **Removes** the tracked `node_modules` symlink.
- **Hardens `.gitignore`**: the entry was `node_modules/` (trailing slash), which makes git ignore only *directories* named `node_modules`. Git stores symlinks as files (mode `120000`), so the symlink never matched the directory-only pattern and slipped through. Dropping the trailing slash makes the pattern match a `node_modules` directory, file, or symlink at any depth, preventing a recurrence.

Verified empirically: with `node_modules/` a root `node_modules` symlink shows as untracked (not ignored); with `node_modules` it is correctly ignored (`git check-ignore` matches `.gitignore:node_modules`).

Fixes #2707

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Affected Components
- [x] CI/CD <!-- repo hygiene / .gitignore -->

## Testing
- [x] I have tested my changes locally
- [ ] I have added/updated unit tests <!-- N/A: change is .gitignore + file removal -->
- [x] All existing tests pass <!-- no code paths affected -->

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary <!-- N/A -->
- [ ] I have added tests for my changes (if applicable) <!-- N/A -->
- [x] My changes follow the project's coding standards

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1zsESbpQPxsFH3nsg9n6m

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1zsESbpQPxsFH3nsg9n6m)_