### PR TITLE
docs: add guidelines for responsible use of AI coding assistants

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -35,6 +35,19 @@ To make review of PRs easier, please:
  * Ensure all new files include a header comment block containing the [Apache License v2.0 and your copyright information](http://www.apache.org/licenses/LICENSE-2.0#apply).
  * If necessary (e.g. due to 3rd party dependency licensing requirements), update the [NOTICE file](https://github.com/finos/architecture-as-code/blob/master/NOTICE) with any new attribution or other notices
 
+### Responsible Use of AI Coding Assistants
+
+AI coding assistants are welcome, but their output must be treated as draft input.
+Before submitting a PR, contributors must understand and be able to explain all
+changes, validate behavior with the project's required checks, and review the
+full diff for correctness, security, privacy, licensing, and dependency impact.
+
+Do not share credentials, confidential information, or private data with AI
+services unless authorized. Contributors remain responsible for the entire
+submission, including any AI-assisted portions.
+
+For full guidance, see [CONTRIBUTING.md](../CONTRIBUTING.md#responsible-use-of-ai-coding-assistants).
+
 
 ### Commit and PR Messages
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,54 @@ For complete details on our commit message rules, see our [`commitlint.config.js
 - Update documentation if you're adding new features
 - Consider the appropriate scope for your changes
 
+## Responsible Use of AI Coding Assistants
+
+This project welcomes the responsible use of AI coding assistants. They can accelerate learning, improve productivity, and help contributors understand the codebase, but AI-generated output should be treated as a draft, not a finished contribution. Contributors remain responsible for every change they submit.
+
+### Understand Before You Submit
+
+Do not submit code you cannot explain. Before opening a pull request, ensure you understand why the change is needed, how it works, its impact on the project, and how you verified that it behaves correctly.
+
+### Use AI as an Assistant, Not an Authority
+
+Treat AI suggestions like code from any unfamiliar contributor. Review and validate them against the project's architecture, coding conventions, documentation, and testing practices rather than assuming they are correct because they compile or appear plausible.
+
+### Start With the Problem
+
+Take time to understand the issue before asking AI to generate code. Focused prompts based on a clear understanding of the problem consistently produce better contributions than asking AI to implement an entire feature from scratch.
+
+### Keep Contributions Focused
+
+AI assistants often generate broader solutions than necessary. Keep pull requests narrowly focused on the problem being solved, minimize unrelated changes, and avoid introducing new abstractions or dependencies unless they are clearly justified.
+
+### Validate Every Change
+
+AI-generated code requires the same level of review and testing as any other contribution. Carefully review the complete diff, run the project's required validation steps, and ensure the implementation and tests accurately solve the intended problem.
+
+### Protect Sensitive Information
+
+Do not share credentials, confidential information, private repository content, or other sensitive data with AI services unless you are authorized to do so. Contributors are responsible for understanding the privacy and data-retention policies of the tools they use.
+
+### Verify, Don't Assume
+
+AI assistants can produce incorrect code, invent APIs, misinterpret project conventions, or generate flawed tests. Verify technical claims using authoritative sources and your own testing rather than relying solely on AI-generated responses.
+
+### Own Your Contribution
+
+AI can help draft code, but it cannot take responsibility for it. Be prepared to explain your design decisions, respond thoughtfully to maintainer feedback, and revise your implementation based on code review.
+
+### Contributor Responsibility
+
+By submitting a contribution, you confirm that you:
+
+1. Reviewed the complete change.
+2. Understand and can explain the implementation.
+3. Verified the change using the project's required validation steps.
+4. Considered security, privacy, licensing, and dependency implications.
+5. Accept responsibility for the entire contribution, including any AI-assisted portions.
+
+Maintainers may reject contributions that appear to be AI-generated but are not sufficiently understood, reviewed, or validated by the contributor.
+
 ## 🚫 What Not to Do
 
 - Don't manually update version numbers in `package.json`

--- a/docs/src/pages/learn/contribute.md
+++ b/docs/src/pages/learn/contribute.md
@@ -79,6 +79,20 @@ git commit -m "docs: update installation instructions"
 Accepted types include `feat`, `fix`, `docs`, `test`, `chore`, `refactor` and
 more; see the repo's `CONTRIBUTING.md` for the full list of types and scopes.
 
+### Responsible use of AI coding assistants
+
+AI coding assistants are welcome, but treat generated code as a draft, not a
+finished contribution. Do not submit code you cannot explain. Keep changes
+focused, review the full diff, run the required validation steps, and verify
+technical claims with project docs and tests.
+
+Do not share credentials or confidential information with AI tools unless you
+are authorized to do so. By opening a PR, you remain responsible for the full
+change, including any AI-assisted portions.
+
+For full guidance, see the repository contributor policy:
+[Responsible Use of AI Coding Assistants](https://github.com/finos/architecture-as-code/blob/main/CONTRIBUTING.md#responsible-use-of-ai-coding-assistants).
+
 ## 6. Open your pull request
 
 Push your branch to your fork and open a pull request against `main`. CI will


### PR DESCRIPTION
## Description
This PR adds contributor guidance on the responsible use of AI coding assistants. It introduces a clear policy for treating AI-generated code as draft input, understanding changes before submission, validating work, and protecting sensitive information.

The guidance is documented in the canonical contributor documentation and also surfaced in the contributor journey page for users visiting the docs site.

Updated files:
- [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md)
- [CONTRIBUTING.md](CONTRIBUTING.md)
- [docs/src/pages/learn/contribute.md](docs/src/pages/learn/contribute.md)

Note: links to documentation files in the repo, e.g., CONTRIBUTING.md and .github/CONTRIBUTING.md, embedded as part of this PR assumes target is on the `main` branch.

## Type of Change
- [x] 📚 Documentation update

## Affected Components
- [x] Documentation

## Commit Message Format ✅
- [x] My commits follow the conventional commit format

## Testing
- [ ] I have tested my changes locally
- [ ] I have added/updated unit tests
- [ ] All existing tests pass

## Checklist
- [x] My commits follow the conventional commit format
- [x] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards